### PR TITLE
executing `netlifyRedirects()` from plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ module.exports = {
   name: require('./package').name,
   outputReady() {
     const netlifyOptions = this.app.options['ember-cli-netlify'];
-    const redirectsFromPlugins = loadNetlifyRedirects(this);
+    const pluginRedirectFunctions = loadNetlifyRedirects(this);
+
+    let redirectsFromPlugins = pluginRedirectFunctions.reduce((redirects, pluginRedirectFunction) => {
+      return redirects.concat(pluginRedirectFunction());
+    }, []);
 
     if (fs.pathExistsSync('.netlifyheaders')) {
       fs.copySync('.netlifyheaders', 'dist/_headers', { clobber: true });


### PR DESCRIPTION
before this change it would essentially add `[function() {}]` to the redirects file 🙈 it was just calling toString() on the array of functions instead of executing them